### PR TITLE
Clean up redundant imports in Main.java

### DIFF
--- a/src/main/java/Main.java
+++ b/src/main/java/Main.java
@@ -7,7 +7,6 @@ import java.util.Random;
 import java.io.InputStream;
 import javax.imageio.ImageIO;
 import org.bytedeco.javacv.*;
-import org.bytedeco.javacv.Frame;
 
 /**
  * Main class that serves as the entry point for the application.
@@ -146,7 +145,7 @@ class BackgroundSnap {
      */
     private BufferedImage takeWebcamPhoto() {
         try {
-            Frame frame = camera.grab();
+            org.bytedeco.javacv.Frame frame = camera.grab();
             if (frame != null) {
                 return converter.convert(frame);
             }

--- a/src/main/java/Main.java
+++ b/src/main/java/Main.java
@@ -1,8 +1,5 @@
 import javax.swing.*;
 import java.awt.*;
-import java.awt.Robot;
-import java.awt.Toolkit;
-import java.awt.GridLayout;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
 import java.awt.image.BufferedImage;


### PR DESCRIPTION
Removed redundant imports `java.awt.Robot`, `java.awt.Toolkit`, and `java.awt.GridLayout` from `src/main/java/Main.java`. These classes are already imported via the wildcard `import java.awt.*;`. verified the build still passes.

---
*PR created automatically by Jules for task [4318015337555089658](https://jules.google.com/task/4318015337555089658) started by @EMorf*