### PR TITLE
⚡ [performance] Cache Robot and Rectangle in BackgroundSnap

### DIFF
--- a/src/main/java/Main.java
+++ b/src/main/java/Main.java
@@ -40,6 +40,8 @@ class BackgroundSnap {
     private final Dimension screenSize;
     private final int targetWidth;
     private final int targetHeight;
+    private volatile Robot robot;
+    private final Rectangle screenRect;
 
     /**
      * Constructor initializes the camera, screen dimensions, and loads the fallback dwarf image.
@@ -49,12 +51,18 @@ class BackgroundSnap {
         camera = new OpenCVFrameGrabber(0);
         converter = new Java2DFrameConverter();
         screenSize = Toolkit.getDefaultToolkit().getScreenSize();
+        screenRect = new Rectangle(screenSize);
         targetWidth = screenSize.width / 2;  // Half the screen width for each image
         targetHeight = screenSize.height;
         try {
             camera.start();
         } catch (Exception e) {
             System.err.println("Failed to start camera: " + e.getMessage());
+        }
+        try {
+            robot = new Robot();
+        } catch (AWTException e) {
+            System.err.println("Failed to initialize Robot: " + e.getMessage());
         }
         loadDwarfImage();
     }
@@ -136,8 +144,9 @@ class BackgroundSnap {
      * @throws Exception if the screenshot capture fails
      */
     private BufferedImage takeScreenshot() throws Exception {
-        Robot robot = new Robot();
-        Rectangle screenRect = new Rectangle(screenSize);
+        if (robot == null) {
+            robot = new Robot();
+        }
         return robot.createScreenCapture(screenRect);
     }
     


### PR DESCRIPTION
The `takeScreenshot` method was previously instantiating a new `Robot` and a new `Rectangle` every time it was called. Given that the screen size is constant, these objects can be safely cached as fields and reused. Caching the `Robot` instance is particularly beneficial as its constructor is resource-intensive. 

The optimization reduces unnecessary allocations and potential overhead during the periodic capture loop. I have also ensured thread safety for the `robot` field by marking it as `volatile`, which is important for the lazy initialization check in the `takeScreenshot` method.

Note: Although a baseline measurement was attempted, it was impractical to demonstrate a significant impact in a headless environment where the full `takeScreenshot` logic (which depends on AWT Robot's native screen capture) cannot be fully executed. However, the theoretical and micro-benchmark benefits of avoiding `Robot` and `Rectangle` instantiation in a hot path are well-established in Java performance engineering.

---
*PR created automatically by Jules for task [2459792805755369631](https://jules.google.com/task/2459792805755369631) started by @EMorf*