### PR TITLE
Refactor imports in Main.java

### DIFF
--- a/src/main/java/Main.java
+++ b/src/main/java/Main.java
@@ -1,12 +1,24 @@
-import javax.swing.*;
-import java.awt.*;
+import javax.swing.ImageIcon;
+import javax.swing.JFrame;
+import javax.swing.JLabel;
+import javax.swing.Timer;
+import java.awt.AWTException;
+import java.awt.Dimension;
+import java.awt.Graphics2D;
+import java.awt.GridLayout;
+import java.awt.Rectangle;
+import java.awt.RenderingHints;
+import java.awt.Robot;
+import java.awt.Toolkit;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
 import java.awt.image.BufferedImage;
 import java.security.SecureRandom;
 import java.io.InputStream;
 import javax.imageio.ImageIO;
-import org.bytedeco.javacv.*;
+import org.bytedeco.javacv.Frame;
+import org.bytedeco.javacv.Java2DFrameConverter;
+import org.bytedeco.javacv.OpenCVFrameGrabber;
 
 /**
  * Main class that serves as the entry point for the application.
@@ -154,7 +166,7 @@ class BackgroundSnap {
      */
     private BufferedImage takeWebcamPhoto() {
         try {
-            org.bytedeco.javacv.Frame frame = camera.grab();
+            Frame frame = camera.grab();
             if (frame != null) {
                 return converter.convert(frame);
             }


### PR DESCRIPTION
This change refactors `src/main/java/Main.java` to replace wildcard imports with explicit imports.

**Changes:**
- Replaced `import java.awt.*;` with explicit imports for `AWTException`, `Dimension`, `Graphics2D`, `GridLayout`, `Rectangle`, `RenderingHints`, `Robot`, and `Toolkit`.
- Replaced `import javax.swing.*;` with explicit imports for `ImageIcon`, `JFrame`, `JLabel`, and `Timer`.
- Replaced `import org.bytedeco.javacv.*;` with explicit imports for `Frame`, `Java2DFrameConverter`, and `OpenCVFrameGrabber`.
- Simplified `org.bytedeco.javacv.Frame` usage to `Frame` in `takeWebcamPhoto` method.

**Why:**
- Improves code readability by clearly showing dependencies.
- Avoids potential naming conflicts (e.g., between `java.awt.Frame` and `org.bytedeco.javacv.Frame`).
- adheres to best practices for Java imports.

**Verification:**
- Ran `gradle build` to ensure the project compiles successfully.
- Verified that all used classes are correctly imported.

---
*PR created automatically by Jules for task [12709392901024171792](https://jules.google.com/task/12709392901024171792) started by @EMorf*