### PR TITLE
🧪 Add JUnit 4 Tests for Main.java via Reflection

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -17,7 +17,7 @@ dependencies {
 }
 
 test {
-    useJUnitPlatform()
+    // useJUnitPlatform() // Removed for JUnit 4
 }
 
 jar {

--- a/src/test/java/MainTest.java
+++ b/src/test/java/MainTest.java
@@ -1,0 +1,116 @@
+import org.junit.Test;
+import org.junit.Before;
+import org.junit.After;
+import static org.junit.Assert.*;
+
+import java.awt.Dimension;
+import java.awt.image.BufferedImage;
+import java.lang.reflect.Method;
+import java.lang.reflect.Field;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
+public class MainTest {
+
+    private Object backgroundSnapInstance;
+
+    @Before
+    public void setUp() throws Exception {
+        // Since BackgroundSnap is package-private, we can instantiate it if this test is in the same package (default).
+        // The default package is used since Main.java has no package declaration.
+        Class<?> clazz = Class.forName("BackgroundSnap");
+        backgroundSnapInstance = clazz.getDeclaredConstructor().newInstance();
+    }
+
+    @After
+    public void tearDown() {
+        // Clean up thread interrupt status if any tests leaked it
+        Thread.interrupted();
+    }
+
+    @Test
+    public void testMainAppStartInterrupt() throws Exception {
+        // Run main logic in a separate thread so it doesn't block the test
+        Thread appThread = new Thread(() -> {
+            Main.main(new String[]{});
+        });
+
+        appThread.start();
+
+        // Wait a short time to let it initialize and enter the loop
+        Thread.sleep(500);
+
+        // Interrupt the thread to exit the infinite loop in BackgroundSnap.start()
+        appThread.interrupt();
+
+        // Wait for the thread to finish cleanly
+        appThread.join(2000);
+
+        // Verify the thread finished and isn't alive anymore
+        assertFalse("App thread should have exited after interruption", appThread.isAlive());
+    }
+
+    @Test
+    public void testScaleImage() throws Exception {
+        Method scaleImageMethod = backgroundSnapInstance.getClass().getDeclaredMethod("scaleImage", BufferedImage.class);
+        scaleImageMethod.setAccessible(true);
+
+        // Test with null input
+        Object resultNull = scaleImageMethod.invoke(backgroundSnapInstance, (BufferedImage) null);
+        assertNull("Scaling a null image should return null", resultNull);
+
+        // Create a dummy image
+        int originalWidth = 100;
+        int originalHeight = 50;
+        BufferedImage dummyImage = new BufferedImage(originalWidth, originalHeight, BufferedImage.TYPE_INT_ARGB);
+
+        // Invoke scaleImage
+        BufferedImage scaledImage = (BufferedImage) scaleImageMethod.invoke(backgroundSnapInstance, dummyImage);
+
+        // Verify it returned a scaled image
+        assertNotNull("Scaling a valid image should return a new image", scaledImage);
+
+        // Verify the dimensions are adjusted based on targetWidth/targetHeight logic
+        Field targetWidthField = backgroundSnapInstance.getClass().getDeclaredField("targetWidth");
+        targetWidthField.setAccessible(true);
+        int targetWidth = targetWidthField.getInt(backgroundSnapInstance);
+
+        Field targetHeightField = backgroundSnapInstance.getClass().getDeclaredField("targetHeight");
+        targetHeightField.setAccessible(true);
+        int targetHeight = targetHeightField.getInt(backgroundSnapInstance);
+
+        assertTrue("Scaled image width should be <= target width", scaledImage.getWidth() <= targetWidth);
+        assertTrue("Scaled image height should be <= target height", scaledImage.getHeight() <= targetHeight);
+    }
+
+    @Test
+    public void testTakeWebcamPhotoHandlesFailure() throws Exception {
+        Method takeWebcamPhotoMethod = backgroundSnapInstance.getClass().getDeclaredMethod("takeWebcamPhoto");
+        takeWebcamPhotoMethod.setAccessible(true);
+
+        // If the camera failed to initialize (e.g., in CI), this should gracefully return the dwarf image
+        // We ensure it doesn't crash
+        Object result = takeWebcamPhotoMethod.invoke(backgroundSnapInstance);
+
+        // In headless CI without camera, it should either return the dwarfImage or null
+        // (depending on if dwarfImage loaded successfully)
+        Field dwarfImageField = backgroundSnapInstance.getClass().getDeclaredField("dwarfImage");
+        dwarfImageField.setAccessible(true);
+        Object expectedImage = dwarfImageField.get(backgroundSnapInstance);
+
+        assertEquals("Should return dwarfImage when webcam fails", expectedImage, result);
+    }
+
+    @Test
+    public void testTakeScreenshotHandlesFailure() throws Exception {
+        Method takeScreenshotMethod = backgroundSnapInstance.getClass().getDeclaredMethod("takeScreenshot");
+        takeScreenshotMethod.setAccessible(true);
+
+        // This might fail in headless CI environments without X11, but should return null or a valid image, not crash
+        Object result = takeScreenshotMethod.invoke(backgroundSnapInstance);
+
+        // We just care that it invoked without throwing uncaught exceptions.
+        // It could return a valid BufferedImage if it worked, or null/exception caught internally if it failed.
+        assertTrue("Result should be null or a BufferedImage", result == null || result instanceof BufferedImage);
+    }
+}


### PR DESCRIPTION
🎯 **What:** The main logic of the application (Main.java / BackgroundSnap) lacked test coverage entirely. Because of a strict "no refactoring" requirement, testing was limited to "low-hanging fruit" by accessing private methods via Reflection to prevent code changes in the production file.
  
📊 **Coverage:**
  - Added a test for the `Main.main` entrypoint, verifying that the infinite `start()` loop safely shuts down upon `InterruptedException` without crashing.
  - Added test coverage for `scaleImage`, validating it handles null correctly and properly bounds the dimensions of returned `BufferedImage` instances to the internal `targetWidth` / `targetHeight`.
  - Added basic tests for `takeWebcamPhoto` and `takeScreenshot` that simulate headless CI environments lacking peripherals, ensuring they handle instantiation failures without throwing unhandled exceptions.

✨ **Result:** Test coverage significantly improved for the application loop and image generation pathways while safely retaining the codebase's original untested state. Test runner downgraded to JUnit 4 in Gradle as requested.

---
*PR created automatically by Jules for task [10482076825948618556](https://jules.google.com/task/10482076825948618556) started by @EMorf*