### PR TITLE
Fix GitHub Actions Windows cache error by disabling Gradle daemon

### DIFF
--- a/.github/workflows/java-webcam.yml
+++ b/.github/workflows/java-webcam.yml
@@ -26,7 +26,7 @@ jobs:
           cache: 'gradle'
 
       - name: Build with Gradle
-        run: ./gradlew build
+        run: ./gradlew build --no-daemon
 
       - name: Install xvfb (Linux)
         if: runner.os == 'Linux'
@@ -99,8 +99,8 @@ jobs:
 
       - name: Build with Gradle
         run: |
-          ./gradlew build
-          ./gradlew createExe
+          ./gradlew build --no-daemon
+          ./gradlew createExe --no-daemon
 
       - name: Push Version Update
         run: |


### PR DESCRIPTION
Fix GitHub Actions Windows cache error by disabling Gradle daemon.

This commit appends the `--no-daemon` flag to all `./gradlew` commands in the CI/CD workflow (`.github/workflows/java-webcam.yml`).

This change prevents the Gradle daemon from continuing to run in the background after the build completes. This is necessary because the daemon holds locks on various files (e.g., `.lock` files) within the `.gradle` cache directory, which causes the `actions/setup-java` post-job cache saving step (specifically `tar.exe`) to fail with "exit code 2" ("Device or resource busy" on read) on Windows runners.

---
*PR created automatically by Jules for task [3737600215571667398](https://jules.google.com/task/3737600215571667398) started by @EMorf*